### PR TITLE
Only use features for publishing data

### DIFF
--- a/collectors/battery.go
+++ b/collectors/battery.go
@@ -3,6 +3,8 @@ package collectors
 import (
 	"log"
 
+	"github.com/hemtjanst/bibliotek/feature"
+
 	"github.com/hemtjanst/bibliotek/server"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -32,10 +34,10 @@ func (c *BatteryCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect sends metric updates into the channel
 func (c *BatteryCollector) Collect(ch chan<- prometheus.Metric) {
-	sensors := c.m.DeviceByType("contactSensor")
-	for _, s := range sensors {
-		if s.Feature("batteryLevel").Exists() {
-			v, err := toFloat(s.Feature("batteryLevel").Value())
+	devices := c.m.Devices()
+	for _, s := range devices {
+		if s.Feature(feature.BatteryLevel.String()).Exists() {
+			v, err := toFloat(s.Feature(feature.BatteryLevel.String()).Value())
 			if err != nil {
 				log.Print(err.Error())
 				continue

--- a/collectors/contact.go
+++ b/collectors/contact.go
@@ -3,6 +3,8 @@ package collectors
 import (
 	"log"
 
+	"github.com/hemtjanst/bibliotek/feature"
+
 	"github.com/hemtjanst/bibliotek/server"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -32,10 +34,10 @@ func (c *ContactCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect sends metric updates into the channel
 func (c *ContactCollector) Collect(ch chan<- prometheus.Metric) {
-	sensors := c.m.DeviceByType("contactSensor")
-	for _, s := range sensors {
-		if s.Feature("contactSensorState").Exists() {
-			v, err := toFloat(s.Feature("contactSensorState").Value())
+	devices := c.m.Devices()
+	for _, s := range devices {
+		if s.Feature(feature.ContactSensorState.String()).Exists() {
+			v, err := toFloat(s.Feature(feature.ContactSensorState.String()).Value())
 			if err != nil {
 				log.Print(err.Error())
 				continue

--- a/collectors/environmental.go
+++ b/collectors/environmental.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"math"
 
+	"github.com/hemtjanst/bibliotek/feature"
+
 	"github.com/hemtjanst/bibliotek/server"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -50,16 +52,13 @@ func (c *EnvironmentalCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect sends metric updates into the channel
 func (c *EnvironmentalCollector) Collect(ch chan<- prometheus.Metric) {
-	sensors := []server.Device{}
-	sensors = append(sensors, c.m.DeviceByType("humiditySensor")...)
-	sensors = append(sensors, c.m.DeviceByType("temperatureSensor")...)
-
+	devices := c.m.Devices()
 	humidity := map[string]float64{}
 	temperature := map[string]float64{}
 
-	for _, s := range sensors {
-		if s.Feature("currentRelativeHumidity").Exists() {
-			v, err := toFloat(s.Feature("currentRelativeHumidity").Value())
+	for _, s := range devices {
+		if s.Feature(feature.CurrentRelativeHumidity.String()).Exists() {
+			v, err := toFloat(s.Feature(feature.CurrentRelativeHumidity.String()).Value())
 			if err != nil {
 				log.Print(err.Error())
 				continue
@@ -68,8 +67,8 @@ func (c *EnvironmentalCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(c.relativeHumidity,
 				prometheus.GaugeValue, v, s.Info().Topic)
 		}
-		if s.Feature("currentTemperature").Exists() {
-			v, err := toFloat(s.Feature("currentTemperature").Value())
+		if s.Feature(feature.CurrentTemperature.String()).Exists() {
+			v, err := toFloat(s.Feature(feature.CurrentTemperature.String()).Value())
 			if err != nil {
 				log.Print(err.Error())
 				continue

--- a/collectors/power.go
+++ b/collectors/power.go
@@ -3,6 +3,8 @@ package collectors
 import (
 	"log"
 
+	"github.com/hemtjanst/bibliotek/feature"
+
 	"github.com/hemtjanst/bibliotek/server"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -53,10 +55,10 @@ func (c *PowerCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect sends metric updates into the channel
 func (c *PowerCollector) Collect(ch chan<- prometheus.Metric) {
-	sensors := c.m.DeviceByType("outlet")
-	for _, s := range sensors {
-		if s.Feature("currentPower").Exists() {
-			v, err := toFloat(s.Feature("currentPower").Value())
+	devices := c.m.Devices()
+	for _, s := range devices {
+		if s.Feature(feature.CurrentPower.String()).Exists() {
+			v, err := toFloat(s.Feature(feature.CurrentPower.String()).Value())
 			if err != nil {
 				log.Print(err.Error())
 				continue
@@ -64,8 +66,8 @@ func (c *PowerCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(c.powerCurrent,
 				prometheus.GaugeValue, v, s.Info().Topic)
 		}
-		if s.Feature("energyUsed").Exists() {
-			v, err := toFloat(s.Feature("energyUsed").Value())
+		if s.Feature(feature.EnergyUsed.String()).Exists() {
+			v, err := toFloat(s.Feature(feature.EnergyUsed.String()).Value())
 			if err != nil {
 				log.Print(err.Error())
 				continue
@@ -73,8 +75,8 @@ func (c *PowerCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(c.powerTotal,
 				prometheus.CounterValue, v, s.Info().Topic)
 		}
-		if s.Feature("currentVoltage").Exists() {
-			v, err := toFloat(s.Feature("currentVoltage").Value())
+		if s.Feature(feature.CurrentVoltage.String()).Exists() {
+			v, err := toFloat(s.Feature(feature.CurrentVoltage.String()).Value())
 			if err != nil {
 				log.Print(err.Error())
 				continue
@@ -82,8 +84,8 @@ func (c *PowerCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(c.voltageCurrent,
 				prometheus.GaugeValue, v, s.Info().Topic)
 		}
-		if s.Feature("currentAmpere").Exists() {
-			v, err := toFloat(s.Feature("currentAmpere").Value())
+		if s.Feature(feature.CurrentAmpere.String()).Exists() {
+			v, err := toFloat(s.Feature(feature.CurrentAmpere.String()).Value())
 			if err != nil {
 				log.Print(err.Error())
 				continue

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/hemtjanst/sensorer
 go 1.12
 
 require (
-	github.com/hemtjanst/bibliotek v0.4.0
+	github.com/hemtjanst/bibliotek v0.4.3
 	github.com/prometheus/client_golang v0.9.2
 )

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,12 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.6.2/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/hemtjanst/bibliotek v0.4.0 h1:tehM76AgERZP3YEiV6i6yKQ/5SQ3T08T0L0gje0RKOQ=
 github.com/hemtjanst/bibliotek v0.4.0/go.mod h1:XUgkn334vr17ADDzcae6fI3wkEVJ1MlgW2TaOQfaEQ0=
+github.com/hemtjanst/bibliotek v0.4.1 h1:cuhAuzNtsQeXuWYHuVjAeIEJcnyWR2AwsuWrP5DY2uc=
+github.com/hemtjanst/bibliotek v0.4.1/go.mod h1:XUgkn334vr17ADDzcae6fI3wkEVJ1MlgW2TaOQfaEQ0=
+github.com/hemtjanst/bibliotek v0.4.2 h1:COtGkWI3Nqk0Ed1mkpeAYOURInrzRGxCQEpDC5SlzZ8=
+github.com/hemtjanst/bibliotek v0.4.2/go.mod h1:XUgkn334vr17ADDzcae6fI3wkEVJ1MlgW2TaOQfaEQ0=
+github.com/hemtjanst/bibliotek v0.4.3 h1:KrCqx50cQaXzA9ocDrqYHwuq6NP2PLwZrCFbyLZFSQ0=
+github.com/hemtjanst/bibliotek v0.4.3/go.mod h1:XUgkn334vr17ADDzcae6fI3wkEVJ1MlgW2TaOQfaEQ0=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=


### PR DESCRIPTION
* Don't search for device type anymore, loop through all devices and
  check if they have a matching feature. This makes us more forwards
  compatible
* Update bibliotek to 0.4.3 so we can use `feature.Type`